### PR TITLE
Feat/zadanie 4: Implementacja metody IfEmployeeCanRequestVacation do sprawdzania możliwości zgłoszenia wniosku urlopowego

### DIFF
--- a/NetDevRecruitingTest.Tests/UnitTests/VacationRequestTests.cs
+++ b/NetDevRecruitingTest.Tests/UnitTests/VacationRequestTests.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetDevRecruitingTest.src.Data;
+using NetDevRecruitingTest.src.Domain;
+using NetDevRecruitingTest.src.Services;
+
+namespace NetDevRecruitingTest.Tests.UnitTests;
+
+[TestFixture]
+public class VacationRequestTests
+{
+    private AppDbContext _context;
+    private IVacationService _service;
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        SeedData(_context);
+        _service = new VacationService(_context);
+    }
+
+    [Test]
+    public void IfEmployeeCanRequestVacation_WithFreeDays_ReturnsTrue()
+    {
+        var jan = _context.Employees.First(e => e.Id == 1);
+        var janVacations = _context.Vacations.Where(v => v.EmployeeId == 1).ToList();
+        var package = _context.VacationPackages.First(p => p.Id == 1);
+
+        var canRequest = _service.IfEmployeeCanRequestVacation(jan, janVacations, package);
+        Assert.That(canRequest, Is.True);  // 15 wolnych dni > 0
+    }
+
+    [Test]
+    public void IfEmployeeCanRequestVacation_NoFreeDays_ReturnsFalse()
+    {
+        // Mock: Dodaj extra vacation dla Jana, by wykorzystać wszystkie 20 dni
+        var extraVacation = new Vacation { Id = 5, EmployeeId = 1, DateSince = new DateTime(2025, 3, 1), DateUntil = new DateTime(2025, 3, 20), IsPartialVacation = false, NumberOfHours = 0 };
+        _context.Vacations.Add(extraVacation);
+        _context.SaveChanges();
+
+        var jan = _context.Employees.First(e => e.Id == 1);
+        var janVacations = _context.Vacations.Where(v => v.EmployeeId == 1).ToList();
+        var package = _context.VacationPackages.First(p => p.Id == 1);
+
+        var canRequest = _service.IfEmployeeCanRequestVacation(jan, janVacations, package);
+        Assert.That(canRequest, Is.False);  // 0 wolnych dni
+    }
+
+    [Test]
+    public void IfEmployeeCanRequestVacation_NoVacations_ReturnsTrue()
+    {
+        var anna = _context.Employees.First(e => e.Id == 3);
+        var annaVacations = _context.Vacations.Where(v => v.EmployeeId == 3).ToList();  // Pusta
+        var package = _context.VacationPackages.First(p => p.Id == 1);
+
+        var canRequest = _service.IfEmployeeCanRequestVacation(anna, annaVacations, package);
+        Assert.That(canRequest, Is.True);  // 20 wolnych dni > 0
+    }
+
+    [Test]
+    public void IfEmployeeCanRequestVacation_NullEmployee_ThrowsException()
+    {
+        var vacations = new List<Vacation>();
+        var package = new VacationPackage { Id = 1, Name = "Standard", GrantedDays = 20, Year = 2025 };
+
+        Assert.Throws<ArgumentNullException>(() => _service.IfEmployeeCanRequestVacation(null, vacations, package));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    private static void SeedData(AppDbContext context)
+    {
+        var netTeam = new Team { Id = 1, Name = ".NET" };
+        var javaTeam = new Team { Id = 2, Name = "Java" };
+        context.Teams.AddRange(netTeam, javaTeam);
+
+        var package = new VacationPackage { Id = 1, Name = "Standard", GrantedDays = 20, Year = 2025 };
+
+        var jan = new Employee { Id = 1, Name = "Jan Kowalski", TeamId = 1, VacationPackageId = 1, PositionId = 1 };
+        var kamil = new Employee { Id = 2, Name = "Kamil Nowak", TeamId = 1, VacationPackageId = 1, PositionId = 1 };
+        var anna = new Employee { Id = 3, Name = "Anna Mariacka", TeamId = 2, VacationPackageId = 1, PositionId = 1 };
+        context.Employees.AddRange(jan, kamil, anna);
+
+        var vacation2025Full = new Vacation { Id = 1, EmployeeId = 1, DateSince = new DateTime(2025, 1, 1), DateUntil = new DateTime(2025, 1, 5), IsPartialVacation = false, NumberOfHours = 0 };
+        var vacation2025Partial = new Vacation { Id = 2, EmployeeId = 2, DateSince = new DateTime(2025, 2, 1), DateUntil = new DateTime(2025, 2, 1), IsPartialVacation = true, NumberOfHours = 4 };
+        var vacationFuture = new Vacation { Id = 3, EmployeeId = 1, DateSince = new DateTime(2025, 10, 1), DateUntil = new DateTime(2025, 10, 5), IsPartialVacation = false, NumberOfHours = 0 };
+
+        context.Vacations.AddRange(vacation2025Full, vacation2025Partial, vacationFuture);
+        context.VacationPackages.Add(package);
+
+        context.SaveChanges();
+    }
+}

--- a/NetDevRecruitingTest/src/Services/IVacationService.cs
+++ b/NetDevRecruitingTest/src/Services/IVacationService.cs
@@ -8,5 +8,6 @@ namespace NetDevRecruitingTest.src.Services
         IEnumerable<(Employee Employee, int UsedDays)> GetEmployeesWithUsedDaysInCurrentYear();
         IEnumerable<Team> GetTeamsWithoutVacationsIn2019();
         int CountFreeDaysForEmployee(Employee employee, List<Vacation> vacations, VacationPackage vacationPackage);
+        bool IfEmployeeCanRequestVacation(Employee employee, List<Vacation> vacations, VacationPackage vacationPackage);
     }
 }

--- a/NetDevRecruitingTest/src/Services/VacationService.cs
+++ b/NetDevRecruitingTest/src/Services/VacationService.cs
@@ -78,5 +78,20 @@ namespace NetDevRecruitingTest.src.Services
             int freeDays = vacationPackage.GrantedDays - (int)usedDays;
             return Math.Max(0, freeDays); // Zapobiegaj ujemnym wartościom
         }
+
+        public bool IfEmployeeCanRequestVacation(Employee employee, List<Vacation> vacations, VacationPackage vacationPackage)
+        {
+            if (employee == null || vacations == null || vacationPackage == null)
+                throw new ArgumentNullException("Pracownik, wakacje ani opcja urlopowa nie mogą być nulllem.");
+
+            if (vacationPackage.Year != DateTime.Now.Year)
+                throw new ArgumentException("Rok pakietu urlopowego musi być ten sam co obecny rok.");
+
+            if (employee.VacationPackageId != vacationPackage.Id)
+                throw new ArgumentException("Paket urlopowy nie pasuje do przypisanego pakietu pracownika.");
+
+            int freeDays = CountFreeDaysForEmployee(employee, vacations, vacationPackage);
+            return freeDays > 0;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -117,3 +117,29 @@ Kod w:
 ### Uruchomienie i testowanie Zadania 3
 - **Demo**: W VS: F5 na NetDevRecruitingTest (rozszerzone o Zad.3). Z terminala: cd NetDevRecruitingTest > dotnet run. Wyświetla free days dla sample employees (Jan:15, Kamil:19, Anna:20) z seed data.
 - **Testy**: W VS: Test Explorer > Run All (4 testy powinny przejść). Z terminala: dotnet test. Coverage: dotnet test --collect:"XPlat Code Coverage" (cel: >90%).
+
+## Zadanie 4: Sprawdzanie możliwości zgłoszenia wniosku urlopowego
+
+### Opis rozwiązania
+Zadanie wymaga zaimplementowania metody `IfEmployeeCanRequestVacation` w klasie `VacationService`, która sprawdza, czy pracownik może złożyć wniosek urlopowy, opierając się na dostępności wolnych dni urlopowych. Rozwiązanie wykorzystuje logikę z zadania 3 (`CountFreeDaysForEmployee`) dla ponownego użycia kodu (DRY), co zapewnia spójność obliczeń. Metoda waliduje wejście (null, zgodność roku i pakietu), filtruje zakończone urlopy w bieżącym roku (30 września 2025 r.) i zwraca `true`, jeśli wolne dni przekraczają 0, w przeciwnym razie `false`. Zgodność z SOLID: SRP (tylko decyzja), OCP (gotowa na rozszerzenie kryteriów). Demo w Program.cs i testy weryfikują różne przypadki.
+
+Kod w:
+- src/Services/IVacationService.cs i VacationService.cs (metoda z LINQ i walidacją).
+- Tests/UnitTests/VacationRequestTests.cs (testy z in-memory DB, edge cases: wolne dni, brak dni, null).
+
+### Zauważone błędy w zadaniu
+- Brak specyfikacji minimalnej liczby dni potrzebnych do wniosku (założono ≥1).
+- Niejasne, czy uwzględniać urlopy trwające (DateSince < Now < DateUntil) – interpretacja "zakończone" wyklucza takie przypadki.
+- Brak definicji bieżącej daty – przyjęto 30 września 2025 r. z kontekstu.
+- Brak obsługi błędów wejścia (null, niezgodność danych) – potencjalne wyjątki runtime.
+
+### Poprawki względem oryginalnego zadania
+- Dodano walidacje: ArgumentNullException dla null, ArgumentException dla mismatched year/package ID – zwiększa robustness.
+- Reuse CountFreeDaysForEmployee – eliminuje duplikację, spójne z zadaniem 3.
+- Filtr: Tylko zakończone urlopy (< Now) i bieżący rok – zgodne z logiką zadania 2b/3.
+- Czysta funkcja: Bez stanu, gotowa na DI dla daty (np. IDateTimeProvider).
+- Testy: Pokrycie scenariuszy (wolne dni, brak dni, null, przyszłe) – brak w oryginale.
+
+### Uruchomienie i testowanie Zadania 4
+- **Demo:** W VS: F5 na NetDevRecruitingTest (rozszerzone o Zad.4). Z terminala: cd NetDevRecruitingTest > dotnet run. Wyświetla wyniki z sample data (np. Jan: true, po wykorzystaniu 20 dni: false).
+- **Testy:** W VS: Test Explorer > Run All (4 testy powinny przejść). Z terminala: dotnet test. Coverage: dotnet test --collect:"XPlat Code Coverage" (cel: >90%).


### PR DESCRIPTION
- Dodano logikę opartą na CountFreeDaysForEmployee (reuse, DRY);
- Walidacja wejścia: null checks, zgodność roku i pakietu z pracownikiem;
- Zwraca true, jeśli wolne dni > 0, false w przeciwnym razie;
- Zgodne z SRP (SOLID): czysta funkcja, tylko decyzja bez modyfikacji;
- Testy w VacationRequestTests.cs pokrywają scenariusze: wolne dni, brak dni, null, przyszłe urlopy;
- Dodanie do README wyjaśnienia rozwiązania zadania 4;